### PR TITLE
Trickle jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.pyc
+*.egg-info
+.tox
+dist
+build
+_build
+doc/hosted_site.cmd

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 build
 _build
 doc/hosted_site.cmd
+.ruffus_history.sqlite

--- a/.hgignore
+++ b/.hgignore
@@ -4,3 +4,4 @@
 _build$
 doc/hosted_site.cmd
 ^.tox
+^.ruffus_history.sqlite$

--- a/.hgignore
+++ b/.hgignore
@@ -3,3 +3,4 @@
 ^dist
 _build$
 doc/hosted_site.cmd
+^.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: python
 python:
   - "2.7"
   - "2.6"
-install:  pip install argparse --use-mirrors
+install:
+  - pip install argparse --use-mirrors
+  - pip install -e .
 script:
   - cd ruffus/test
   - sh run_all_unit_tests.cmd

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: python
 python:
   - "2.7"
   - "2.6"
-install:  pip install tox
-script:  tox
+install:  pip install argparse --use-mirrors
+script:
+  - cd ruffus/test
+  - sh run_all_unit_tests.cmd

--- a/ruffus/file_name_parameters.py
+++ b/ruffus/file_name_parameters.py
@@ -478,7 +478,7 @@ def file_names_from_tasks_globs(files_task_globs,
     for g in files_task_globs.globs:
         task_or_glob_to_files[g] = sorted(glob.glob(g))
     for t in files_task_globs.tasks:
-        of = t.get_output_files(False, runtime_data)
+        of = t.get_output_files(False, runtime_data, reset_cache=True) # reset cache since this is being called after parent tasks are run
         task_or_glob_to_files[t] = of
     for n in files_task_globs.runtime_data_names:
         data_name = n.args[0]

--- a/ruffus/task.py
+++ b/ruffus/task.py
@@ -2679,7 +2679,7 @@ def make_job_parameter_generator (incomplete_tasks, complete_jobs, task_parents,
                         log_at_level (logger, 10, verbose, "   task %s blocked upstream" % t._name)
                         continue
 
-                    log_at_level (logger, 10, verbose, "   job_parameter_generator start task %s (parents completed)" % t._name)
+                    log_at_level (logger, 10, verbose, "   job_parameter_generator start task %s (parents complete or running)" % t._name)
                     force_rerun = t in forcedtorun_tasks
                     #
                     # log task

--- a/ruffus/test/run_all_unit_tests.cmd
+++ b/ruffus/test/run_all_unit_tests.cmd
@@ -45,4 +45,6 @@ python ./test_active_if.py -j2 -v                                               
 echo Running test_softlink_uptodate.py                                              && \
 python ./test_softlink_uptodate.py -j2 -v                                           && \
 echo Running test_job_completion_checksums.py                                       && \
-python -m unittest test_job_completion_checksums
+python -m unittest test_job_completion_checksums                                    && \
+echo Running test_job_trickling.py                                                  && \
+python -m unittest test_job_trickling

--- a/ruffus/test/run_all_unit_tests.cmd
+++ b/ruffus/test/run_all_unit_tests.cmd
@@ -44,5 +44,5 @@ echo Running test_active_if.py                                                  
 python ./test_active_if.py -j2 -v                                                   && \
 echo Running test_softlink_uptodate.py                                              && \
 python ./test_softlink_uptodate.py -j2 -v                                           && \
-echo Running test_job_completion_transform.py                                       && \
+echo Running test_job_completion_checksums.py                                       && \
 python -m unittest test_job_completion_checksums

--- a/ruffus/test/test_job_trickling.py
+++ b/ruffus/test/test_job_trickling.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+"""
+
+    test_job_completion_transform.py
+
+        test several cases where the dbdict should be updated
+
+"""
+
+
+import unittest
+import os
+import sys
+import shutil
+from StringIO import StringIO
+import time
+
+exe_path = os.path.split(os.path.abspath(sys.argv[0]))[0]
+sys.path.insert(0, os.path.abspath(os.path.join(exe_path,"..", "..")))
+from ruffus import (pipeline_run, pipeline_printout, suffix, transform, split,
+                    merge, dbdict, mkdir, follows)
+from ruffus.ruffus_utility import (RUFFUS_HISTORY_FILE,
+                                   CHECKSUM_FILE_TIMESTAMPS,
+                                   CHECKSUM_HISTORY_TIMESTAMPS,
+                                   CHECKSUM_FUNCTIONS,
+                                   CHECKSUM_FUNCTIONS_AND_PARAMS)
+from ruffus.ruffus_exceptions import RethrownJobError
+
+possible_chksms = range(CHECKSUM_FUNCTIONS_AND_PARAMS + 1)
+workdir = 'tmp_test_job_completion/'
+input_file = os.path.join(workdir, 'input.txt')
+transform1_out = input_file.replace('.txt', '.output')
+split1_outputs = [ os.path.join(workdir, 'split.out1.txt'),
+                   os.path.join(workdir, 'split.out2.txt'),
+                   os.path.join(workdir, 'split.other.file.*.txt')]
+merge2_output =  os.path.join(workdir, 'merged.out')
+
+runtime_data = []
+
+#@follows(mkdir(workdir + '/test'))
+@transform(input_file, suffix('.txt'), '.output', runtime_data)
+def transform1(in_name, out_name, how_many):
+    with open(out_name, 'w') as outfile:
+        outfile.write(open(in_name).read())
+
+@transform(input_file, suffix('.txt'), '.output', runtime_data)
+def transform_raise_error(in_name, out_name, how_many):
+    # raise an error unless runtime_data has 'okay' in it
+    with open(out_name, 'w') as outfile:
+        outfile.write(open(in_name).read())
+    if 'okay' not in runtime_data:
+        raise RuntimeError("'okay' wasn't in runtime_data!")
+
+@split(input_file, split1_outputs)
+def split1(in_name, out_names):
+    for n in out_names:
+        if '*' in n:
+            n = n.replace('*', 'number1')
+        with open(n, 'w') as outfile:
+            outfile.write(open(in_name).read() + '\n')
+
+@merge(split1, merge2_output)
+def merge2(in_names, out_name):
+    with open(out_name, 'w') as outfile:
+        for n in in_names:
+            outfile.write(open(n).read() + '\n')
+
+
+#CHECKSUM_FILE_TIMESTAMPS      = 0     # only rerun when the file timestamps are out of date (classic mode)
+#CHECKSUM_HISTORY_TIMESTAMPS   = 1     # also rerun when the history shows a job as being out of date
+#CHECKSUM_FUNCTIONS            = 2     # also rerun when function body has changed
+#CHECKSUM_FUNCTIONS_AND_PARAMS = 3     # also rerun when function parameters have changed
+
+
+def cleanup_tmpdir():
+    os.system('rm -f %s %s' % (os.path.join(workdir, '*'), RUFFUS_HISTORY_FILE))
+
+
+class TestJobCompletion(unittest.TestCase):
+    def setUp(self):
+        try:
+            os.mkdir(workdir)
+        except OSError:
+            pass
+
+    def test_ouput_doesnt_exist(self):
+        """Input file exists, output doesn't exist"""
+        # output doesn't exist-- should run for all levels
+        # create a new input file
+        cleanup_tmpdir()
+        with open(input_file, 'w') as outfile:
+            outfile.write('testme')
+
+        for chksm in possible_chksms:
+            s = StringIO()
+            pipeline_printout(s, [transform1], verbose=10, checksum_level=chksm)
+            self.assertIn('Job needs update: Missing file [tmp_test_job_completion/input.output]',
+                          s.getvalue())
+
+
+
+    def tearDown(self):
+        shutil.rmtree(workdir)
+
+if __name__ == '__main__':
+    try:
+        os.mkdir(workdir)
+    except OSError:
+        pass
+    os.system('rm %s/*' % workdir)
+    with open(input_file, 'w') as outfile:
+        outfile.write('this is a test\n')
+    s = StringIO()
+    pipeline_run([transform1, merge2], verbose=100)
+    #pipeline_printout(s, [transform1], verbose=100, checksum_level=0)
+    print s.getvalue()
+    #open(transform1_out)  # raise an exception if test fails

--- a/ruffus/test/test_job_trickling.py
+++ b/ruffus/test/test_job_trickling.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 """
 
-    test_job_completion_transform.py
+    test_job_trickling.py
 
-        test several cases where the dbdict should be updated
+        test if the jobs are trickling to their child tasks
 
 """
 
@@ -14,63 +14,47 @@ import sys
 import shutil
 from StringIO import StringIO
 import time
+import glob
+from multiprocessing.pool import ThreadPool
 
 exe_path = os.path.split(os.path.abspath(sys.argv[0]))[0]
 sys.path.insert(0, os.path.abspath(os.path.join(exe_path,"..", "..")))
 from ruffus import (pipeline_run, pipeline_printout, suffix, transform, split,
                     merge, dbdict, mkdir, follows)
-from ruffus.ruffus_utility import (RUFFUS_HISTORY_FILE,
-                                   CHECKSUM_FILE_TIMESTAMPS,
-                                   CHECKSUM_HISTORY_TIMESTAMPS,
-                                   CHECKSUM_FUNCTIONS,
-                                   CHECKSUM_FUNCTIONS_AND_PARAMS)
+from ruffus.ruffus_utility import RUFFUS_HISTORY_FILE
 from ruffus.ruffus_exceptions import RethrownJobError
 
-possible_chksms = range(CHECKSUM_FUNCTIONS_AND_PARAMS + 1)
-workdir = 'tmp_test_job_completion/'
+workdir = 'tmp_test_job_trickling/'
 input_file = os.path.join(workdir, 'input.txt')
-transform1_out = input_file.replace('.txt', '.output')
-split1_outputs = [ os.path.join(workdir, 'split.out1.txt'),
-                   os.path.join(workdir, 'split.out2.txt'),
-                   os.path.join(workdir, 'split.other.file.*.txt')]
-merge2_output =  os.path.join(workdir, 'merged.out')
-
-runtime_data = []
-
-#@follows(mkdir(workdir + '/test'))
-@transform(input_file, suffix('.txt'), '.output', runtime_data)
-def transform1(in_name, out_name, how_many):
-    with open(out_name, 'w') as outfile:
-        outfile.write(open(in_name).read())
-
-@transform(input_file, suffix('.txt'), '.output', runtime_data)
-def transform_raise_error(in_name, out_name, how_many):
-    # raise an error unless runtime_data has 'okay' in it
-    with open(out_name, 'w') as outfile:
-        outfile.write(open(in_name).read())
-    if 'okay' not in runtime_data:
-        raise RuntimeError("'okay' wasn't in runtime_data!")
+split1_outputs = [os.path.join(workdir, 'split.%s.txt' % i) for i in range(5)]
+transform2_outputs = [f.replace('.txt', '.output1') for f in split1_outputs]
+transform3_outputs = [f.replace('.output1', '.output2') for f in transform2_outputs]
+merge3_output =  os.path.join(workdir, 'merged.out')
 
 @split(input_file, split1_outputs)
 def split1(in_name, out_names):
     for n in out_names:
-        if '*' in n:
-            n = n.replace('*', 'number1')
         with open(n, 'w') as outfile:
             outfile.write(open(in_name).read() + '\n')
 
-@merge(split1, merge2_output)
-def merge2(in_names, out_name):
+@transform(split1, suffix('.txt'), '.output1')
+def transform2_variable_wait(in_name, out_name):
+    if 'split.0.txt' in in_name:
+        print 'waiting'
+        time.sleep(10)  # simulate a long-running job
+    with open(out_name, 'w') as outfile:
+        outfile.write(open(in_name).read())
+
+@transform(transform2_variable_wait, suffix('.output1'), '.output2')
+def transform3(in_name, out_name):
+    with open(out_name, 'w') as outfile:
+        outfile.write(open(in_name).read())
+
+@merge(transform3, merge3_output)
+def merge4(in_names, out_name):
     with open(out_name, 'w') as outfile:
         for n in in_names:
             outfile.write(open(n).read() + '\n')
-
-
-#CHECKSUM_FILE_TIMESTAMPS      = 0     # only rerun when the file timestamps are out of date (classic mode)
-#CHECKSUM_HISTORY_TIMESTAMPS   = 1     # also rerun when the history shows a job as being out of date
-#CHECKSUM_FUNCTIONS            = 2     # also rerun when function body has changed
-#CHECKSUM_FUNCTIONS_AND_PARAMS = 3     # also rerun when function parameters have changed
-
 
 def cleanup_tmpdir():
     os.system('rm -f %s %s' % (os.path.join(workdir, '*'), RUFFUS_HISTORY_FILE))
@@ -82,36 +66,29 @@ class TestJobCompletion(unittest.TestCase):
             os.mkdir(workdir)
         except OSError:
             pass
-
-    def test_ouput_doesnt_exist(self):
-        """Input file exists, output doesn't exist"""
-        # output doesn't exist-- should run for all levels
-        # create a new input file
+        
+    def test_fast_jobs_done(self):
+        """Validate that fast outputs are available before the slow outputs"""
         cleanup_tmpdir()
         with open(input_file, 'w') as outfile:
             outfile.write('testme')
-
-        for chksm in possible_chksms:
-            s = StringIO()
-            pipeline_printout(s, [transform1], verbose=10, checksum_level=chksm)
-            self.assertIn('Job needs update: Missing file [tmp_test_job_completion/input.output]',
-                          s.getvalue())
-
-
+        
+        def step2_output_when_step1_was_running():
+            """assert that there was a time when step 3 was running, but step 2 hadn't finished"""
+            found = False
+            for i in range(5):
+                time.sleep(1)
+                num_step2 = sum(map(os.path.exists, transform2_outputs))
+                num_step3 = sum(map(os.path.exists, transform3_outputs))
+                if num_step3 > 0 and num_step2 < len(transform2_outputs):
+                    found = True
+            return found
+        
+        p = ThreadPool(processes=1)
+        r = p.apply_async(step2_output_when_step1_was_running)
+        pipeline_run([merge4], verbose=3)
+        self.assertTrue(r.get())
 
     def tearDown(self):
+        cleanup_tmpdir()
         shutil.rmtree(workdir)
-
-if __name__ == '__main__':
-    try:
-        os.mkdir(workdir)
-    except OSError:
-        pass
-    os.system('rm %s/*' % workdir)
-    with open(input_file, 'w') as outfile:
-        outfile.write('this is a test\n')
-    s = StringIO()
-    pipeline_run([transform1, merge2], verbose=100)
-    #pipeline_printout(s, [transform1], verbose=100, checksum_level=0)
-    print s.getvalue()
-    #open(transform1_out)  # raise an exception if test fails


### PR DESCRIPTION
Phew!  That was a lot more convoluted than I thought that it would be, but I think I've covered all the bases and am ready to submit this pull request.  It _finally_ passes all the unittests, including a new set that tests specifically for "trickling".  

The solution was quite complicated thanks to a fair few edge cases I hadn't thought of, but the idea is simple: just maintain a set of output files that have been completed, then allow tasks to be "considered" when their ancestors have all had at least one job submitted. Regardless of the overall task completion state, jobs are submitted when their inputs are complete.

Several job categories are considered "blocking" and will not allow any downstream trickling until all jobs in the task are complete:
1.  jobs with indeterminate (globbed) output
2.  jobs with an explicit `@follows` list which is incomplete
3.  jobs whose incomplete ancestors fit into any of the categories above

Also, tasks with globbed input have to wait for the completion of upstream tasks before being considered.

It would be great to have the indefinitely-running task you mentioned before and I think it would actually be pretty easy to add, given the changes outlined here.  The code that determines if a task is really complete would just need to be special cased (never remove a forever-running task).

Have a look at the code, particularly check out the "Files changed" mode above which collapses all the (many) commits into a single diff.
