### PR TITLE
removal of meaningless condition & concise mkdir task names

### DIFF
--- a/ruffus/task.py
+++ b/ruffus/task.py
@@ -3368,8 +3368,7 @@ class Task (node):
         #   Create a new Task with a unique name to this instance of mkdir
         #
         self.cnt_task_mkdir += 1
-        cnt_task_mkdir_str = (" #%d" % self.cnt_task_mkdir) if self.cnt_task_mkdir > 1 else ""
-        task_name = r"mkdir%r%s   before %s " % (unnamed_args, cnt_task_mkdir_str, self._name)
+        task_name = r"mkdir before %s " % (self._name)
         task_name = task_name.replace(",)", ")").replace(",", ",  ")
         new_task = self.pipeline._create_task(task_func=job_wrapper_mkdir, task_name=task_name)
 

--- a/ruffus/task.py
+++ b/ruffus/task.py
@@ -4509,9 +4509,8 @@ def _pipeline_prepare_to_run(checksum_level, history_file, pipeline, runtime_dat
     if not target_tasks:
         if pipeline:
             target_tasks.extend(list(pipeline.tasks))
-        if not target_tasks:
-            for pipeline_name in Pipeline.pipelines.keys():
-                target_tasks.extend(list(Pipeline.pipelines[pipeline_name].tasks))
+        for pipeline_name in Pipeline.pipelines.keys():
+            target_tasks.extend(list(Pipeline.pipelines[pipeline_name].tasks))
 
     # make sure pipeline is defined
     pipeline = lookup_pipeline(pipeline)


### PR DESCRIPTION
Removed a meaningless condition
Use concise mkdir task names, which appears to be prettier on final graph using `ruffus.pipeline_printout_graph`
