### PR TITLE
Fix typo in sys.hexversion comparison

### DIFF
--- a/ruffus/test/test_newstyle_regex_error_messages.py
+++ b/ruffus/test/test_newstyle_regex_error_messages.py
@@ -275,7 +275,7 @@ class Test_regex_error_messages(unittest.TestCase):
         if sys.hexversion < 0x03000000:
             self.assertRaisesRegex = self.assertRaisesRegexp27
 
-        if sys.hexversion < 0x02700000:
+        if sys.hexversion < 0x02070000:
             self.assertIn = self.my_assertIn
 
     def my_assertIn (self, test_string, full_string):

--- a/ruffus/test/test_regex_error_messages.py
+++ b/ruffus/test/test_regex_error_messages.py
@@ -260,7 +260,7 @@ class Test_regex_error_messages(unittest.TestCase):
         if sys.hexversion < 0x03000000:
             self.assertRaisesRegex = self.assertRaisesRegexp27
 
-        if sys.hexversion < 0x02700000:
+        if sys.hexversion < 0x02070000:
             self.assertIn = self.my_assertIn
 
     def my_assertIn (self, test_string, full_string):


### PR DESCRIPTION
0x02700000 corresponds to Python 2.112;
0x02070000 corresponds to Python 2.7.
I guess you meant the latter. :-P

BTW, in the long run, I'd recommend using `sys.version_info` instead, which is more readable and less error-prone.