### PR TITLE
Ah add gevent pool compatibility

### DIFF
--- a/ruffus/ruffus_version.py
+++ b/ruffus/ruffus_version.py
@@ -24,4 +24,4 @@
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #   THE SOFTWARE.
 #################################################################################
-__version='2.6.3'
+__version = '2.7.0'

--- a/ruffus/task.py
+++ b/ruffus/task.py
@@ -94,8 +94,6 @@ import collections
 import logging
 import re
 from collections import defaultdict, deque
-from multiprocessing import Pool
-from multiprocessing.pool import ThreadPool
 import traceback
 import types
 if sys.hexversion >= 0x03000000:
@@ -901,7 +899,11 @@ class Pipeline(dict):
 
         self.command_str_callback = subprocess_checkcall_wrapper
 
-
+    @classmethod
+    def clear_all(cls):
+        """clear all pipelines.
+        """
+        cls.pipelines = dict()
     # _________________________________________________________________________
 
     #   _create_task
@@ -974,7 +976,6 @@ class Pipeline(dict):
         Make sure all tasks in dependency list are linked to real functions
         """
 
-
         processed_pipelines = set([self.name])
         unprocessed_tasks = deque(self.tasks)
         while len(unprocessed_tasks):
@@ -995,7 +996,6 @@ class Pipeline(dict):
             if isinstance(task._is_single_job_single_output, Task):
                 task._is_single_job_single_output = \
                     task._is_single_job_single_output._is_single_job_single_output
-
 
         for pipeline_name in list(processed_pipelines):
             if pipeline_name != self.name:
@@ -4424,12 +4424,8 @@ def lookup_pipeline(pipeline):
     raise error_not_a_pipeline("%s does not name a pipeline." % pipeline)
 
 
-
-
 # _____________________________________________________________________________
-
 #   _pipeline_prepare_to_run
-
 # _____________________________________________________________________________
 def _pipeline_prepare_to_run(checksum_level, history_file, pipeline, runtime_data, target_tasks, forcedtorun_tasks):
     """
@@ -5438,13 +5434,13 @@ def pipeline_run(target_tasks=[],
                  history_file=None,
                  # defaults to 2 if None
                  verbose_abbreviated_path=None,
-                 pipeline=None):
+                 pipeline=None,
+                 pool_manager="multiprocessing"):
     # Remember to add further extra parameters here to
     #   "extra_pipeline_run_options" inside cmdline.py
     # This will forward extra parameters from the command line to
     # pipeline_run
-    """
-    Run pipelines.
+    """Run pipelines.
 
     :param target_tasks: targets task functions which will be run if they are
                          out-of-date
@@ -5459,7 +5455,7 @@ def pipeline_run(target_tasks=[],
                         is particularly useful to manage high performance
                         clusters which otherwise are prone to
                         "processor storms" when large number of cores finish
-                        jobs at the same time. (Thanks Andreas Heger)
+                        jobs at the same time.
     :param logger: Where progress will be logged. Defaults to stderr output.
     :type logger: `logging <http://docs.python.org/library/logging.html>`_
                   objects
@@ -5547,17 +5543,33 @@ def pipeline_run(target_tasks=[],
     syncmanager = multiprocessing.Manager()
 
     #
-    #   whether using multiprocessing or multithreading
-    #
-    if multithread:
-        pool = ThreadPool(multithread)
-        parallelism = multithread
-    elif multiprocess > 1:
-        pool = Pool(multiprocess)
-        parallelism = multiprocess
-    else:
-        parallelism = 1
-        pool = None
+    #   select pool and queue type. Selection is convoluted
+    #   for backwards compatibility.
+    itr_kwargs = {}
+    parallelism = max(multiprocess, multithread)
+    if parallelism > 1:
+        if pool_manager == "multiprocessing":
+            if multithread:
+                pool_t = multiprocessing.pool.ThreadPool
+                queue_t = queue.Queue
+            elif multiprocess > 1:
+                pool_t = multiprocessing.Pool
+                queue_t = queue.Queue
+                #   Use a timeout of 3 years per job..., so that the condition
+                #       we are waiting for in the thread can be interrupted by
+                #       signals... In other words, so that Ctrl-C works
+                #   Yucky part is that timeout is an extra parameter to
+                #       IMapIterator.next(timeout=None) but next() for normal
+                #       iterators do not take any extra parameters.
+                itr_kwargs = dict(timeout=99999999)
+        elif pool_manager == "gevent":
+            import gevent
+            import gevent.pool
+            pool_t = gevent.pool.Pool
+            queue_t = gevent.queue.Queue
+        else:
+            raise ValueError("unknown pool manager '{}'".format(pool_manager))
+    pool = pool_t(parallelism)
 
     if verbose == 0:
         logger = black_hole_logger
@@ -5568,7 +5580,6 @@ def pipeline_run(target_tasks=[],
         #       are tagged
         if hasattr(logger, "add_unique_prefix"):
             logger.add_unique_prefix()
-
 
     (checksum_level,
      job_history,
@@ -5701,8 +5712,8 @@ def pipeline_run(target_tasks=[],
     # prime queue with initial set of job parameters
     #
     death_event = syncmanager.Event()
-    parameter_q = queue.Queue()
-    task_with_completed_job_q = queue.Queue()
+    parameter_q = queue_t()
+    task_with_completed_job_q = queue_t()
     parameter_generator = make_job_parameter_generator(incomplete_tasks, task_parents,
                                                        logger, forcedtorun_tasks,
                                                        task_with_completed_job_q,
@@ -5751,7 +5762,7 @@ def pipeline_run(target_tasks=[],
     #      except StopIteration:
     #          break
 
-    if pool:
+    if pool is not None:
         pool_func = pool.imap_unordered
     else:
         pool_func = map
@@ -5777,14 +5788,8 @@ def pipeline_run(target_tasks=[],
         # feed_job_params_to_process_pool()):
         ii = iter(pool_func(run_pooled_job_without_exceptions, feed_job_params_to_process_pool()))
         while 1:
-            #   Use a timeout of 3 years per job..., so that the condition
-            #       we are waiting for in the thread can be interrupted by
-            #       signals... In other words, so that Ctrl-C works
-            #   Yucky part is that timeout is an extra parameter to
-            #       IMapIterator.next(timeout=None) but next() for normal
-            #       iterators do not take any extra parameters.
-            if pool:
-                job_result = ii.next(timeout=99999999)
+            if pool is not None:
+                job_result = ii.next(**itr_kwargs)
             else:
                 job_result = next(ii)
             # run next task
@@ -5917,9 +5922,10 @@ def pipeline_run(target_tasks=[],
         except:
             pass
 
-        if pool:
-            log_at_level(logger, 10, verbose, "       pool.close")
-            pool.close()
+        if pool is not None:
+            if hasattr(pool, "close"):
+                log_at_level(logger, 10, verbose, "       pool.close")
+                pool.close()
             log_at_level(logger, 10, verbose, "       pool.terminate")
             try:
                 pool.terminate()
@@ -5931,16 +5937,21 @@ def pipeline_run(target_tasks=[],
     # log_at_level (logger, 10, verbose, "       syncmanager.shutdown")
     # syncmanager.shutdown()
 
-    if pool:
+    if pool is not None:
         log_at_level(logger, 10, verbose, "       pool.close")
         # pool.join()
-        pool.close()
+        try:
+            pool.close()
+        except AttributeError:
+            pass
         log_at_level(logger, 10, verbose, "       pool.terminate")
-        # an exception may be thrown after a signal is caught (Ctrl-C)
-        #   when the EventProxy(s) for death_event might be left hanging
         try:
             pool.terminate()
-        except:
+        except AttributeError:
+            pass
+        except Exception:
+            # an exception may be thrown after a signal is caught (Ctrl-C)
+            #   when the EventProxy(s) for death_event might be left hanging
             pass
         log_at_level(logger, 10, verbose, "       pool.terminated")
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
-from distutils.core import setup
-#from setuptools import find_packages
+import sys
+import os
+from setuptools import setup
 
-import sys, os
-if not sys.version_info[0:2] >= (2,6):
+if not sys.version_info[0:2] >= (2, 6):
     sys.stderr.write("Requires Python later than 2.6\n")
     sys.exit(1)
 
@@ -11,7 +11,6 @@ if not sys.version_info[0:2] >= (2,6):
 sys.path.insert(0, os.path.abspath("."))
 import ruffus.ruffus_version
 sys.path.pop(0)
-
 
 module_dependencies = []
 #module_dependencies = ['multiprocessing>=2.6', 'simplejson']

--- a/test/test_pipeline_control.py
+++ b/test/test_pipeline_control.py
@@ -1,0 +1,145 @@
+
+import contextlib
+import unittest
+import ruffus
+import os
+import numpy
+import shutil
+import glob
+import tempfile
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
+TESTS_TEMPDIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "tmp"))
+
+# number of cores used for testing parallelism
+NUM_CORES = 4
+
+
+@contextlib.contextmanager
+def temp_cd(target):
+    curdir = os.path.curdir
+    os.chdir(target)
+    yield
+    os.chdir(curdir)
+
+
+def save_pid(outfile):
+    with open(outfile + ".pid", "w") as outf:
+        outf.write("{}".format(os.getpid()))
+
+
+def create_files(outfile):
+    with open(outfile, "w") as outf:
+        outf.write("\n".join(map(
+            str,
+            numpy.random.normal(0.5, 0.1, 100))) + "\n")
+    save_pid(outfile)
+
+
+def compute_mean(infile, outfile):
+    """compute mean"""
+    with open(infile, "r") as inf:
+        n = [float(x.strip()) for x in inf.readlines()]
+
+    with open(outfile, "w") as outf:
+        outf.write("{}\n".format(sum(n) / len(n)))
+    save_pid(outfile)
+
+
+def combine_means(infiles, outfile):
+    with open(outfile, "w") as outf:
+        for infile in infiles:
+            with open(infile) as inf:
+                outf.write(inf.read())
+    save_pid(outfile)
+
+
+class BaseTest(unittest.TestCase):
+
+    expected_output_files = ["sample_{:02}.mean".format(x) for x in range(10)] +\
+                            ["sample_{:02}.txt".format(x) for x in range(10)]
+
+    def setUp(self):
+        try:
+            os.makedirs(TESTS_TEMPDIR)
+        except OSError:
+            pass
+        self.work_dir = tempfile.mkdtemp(suffix="",
+                                         prefix="ruffus_tmp_{}_".format(self.id()),
+                                         dir=TESTS_TEMPDIR)
+
+    def tearDown(self):
+        shutil.rmtree(self.work_dir)
+
+    def check_files(self, present=[], absent=[]):
+        for fn in present:
+            path = os.path.join(self.work_dir, fn)
+            self.assertTrue(os.path.exists(path),
+                            "file {} does not exist".format(path))
+        for fn in absent:
+            path = os.path.join(self.work_dir, fn)
+            self.assertFalse(os.path.exists(path),
+                             "file {} does exist but not expected".format(path))
+
+    def build_pipeline(self, pipeline_name):
+        # fudge: clear all previous pipelines
+        ruffus.Pipeline.clear_all()
+        pipeline = ruffus.Pipeline(pipeline_name)
+
+        task_create_files = pipeline.originate(
+            task_func=create_files,
+            output=["sample_{:02}.txt".format(x) for x in range(10)])
+
+        task_compute_mean = pipeline.transform(
+            task_func=compute_mean,
+            input=task_create_files,
+            filter=ruffus.suffix(".txt"),
+            output=".mean")
+
+        task_combine_means = pipeline.merge(
+            task_func=combine_means,
+            input=task_compute_mean,
+            output="means.txt")
+
+    def run_pipeline(self, **kwargs):
+        pipeline = self.build_pipeline(self.id())
+        with temp_cd(self.work_dir):
+            ruffus.pipeline_run(pipeline=pipeline, **kwargs)
+        self.check_files(self.expected_output_files)
+
+    def read_pids(self):
+        pids = []
+        for fn in glob.glob(os.path.join(self.work_dir, "*.pid")):
+            with open(fn) as inf:
+                pids.append(int(inf.readline().strip()))
+        return pids
+
+
+class TestExecutionEngines(BaseTest):
+
+    def test_pipeline_runs_with_multiprocessing(self):
+        self.run_pipeline(multiprocess=NUM_CORES)
+        pids = self.read_pids()
+        self.assertEqual(len(set(pids)), NUM_CORES)
+
+    def test_pipeline_runs_with_multithreading(self):
+        self.run_pipeline(multithread=NUM_CORES)
+        pids = self.read_pids()
+        self.assertEqual(len(set(pids)), 1)
+        self.assertEqual(pids[0], os.getpid())
+
+    def test_pipeline_runs_with_gevent_manager(self):
+        self.run_pipeline(multithread=NUM_CORES, pool_manager="gevent")
+        pids = self.read_pids()
+        self.assertEqual(len(set(pids)), 1)
+        self.assertEqual(pids[0], os.getpid())
+
+    def test_pipeline_fails_with_unknown_manager(self):
+        self.assertRaises(ValueError,
+                          self.run_pipeline,
+                          multithread=NUM_CORES,
+                          pool_manager="mystical_manager")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds the ability to use gevent as pool manager in addition to multiprocessing ThreadPool and multiprocessing Pool.

gevent uses cooperative multi-tasking. The benefit over ThreadPool is that the pipeline lives in a single process/thread thus avoiding any copying of objects to threads. This copying can become an issue in large and complex pipelines.

See here https://github.com/JohnStarich/python-pool-performance for a very nice benchmark.