### PR TITLE
Remove functions deprecated in Python 3.7

### DIFF
--- a/ruffus/task.py
+++ b/ruffus/task.py
@@ -710,9 +710,7 @@ t_job_result = namedtuple('t_job_result',
                           'return_value '
                           'exception '
                           'params '
-                          'unglobbed_params ',
-                          verbose=0)
-
+                          'unglobbed_params ')
 
 # _____________________________________________________________________________
 

--- a/ruffus/task.py
+++ b/ruffus/task.py
@@ -5968,13 +5968,6 @@ def pipeline_run(target_tasks=[],
         raise job_errors
 
 
-#   use high resolution timestamps where available
-#       default in python 2.5 and greater
-#   N.B. File modify times / stat values have 1 second precision for many file
-#       systems and may not be accurate to boot, especially over the network.
-os.stat_float_times(True)
-
-
 if __name__ == '__main__':
     import unittest
 


### PR DESCRIPTION
ruffus fails to install or run on Python 3.7 because it uses APIs that were removed.