### PR TITLE
Fix sphinx.ext.mathjax: other math package is already loaded

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,7 +36,7 @@ def setup(app):
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.todo',
-              'sphinx.ext.coverage', 'sphinx.ext.pngmath', 'sphinx.ext.mathjax', 'sphinx.ext.ifconfig', 'sphinx.ext.viewcode']
+              'sphinx.ext.coverage', 'sphinx.ext.mathjax', 'sphinx.ext.ifconfig', 'sphinx.ext.viewcode']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
This is a patch on the [Debian patch tracker](https://sources.debian.org/patches/python-ruffus/2.7-1/sphinx.ext.pngmath_deprecated.patch/) that I put into a PR so that it doesn't get lost.