### PR TITLE
setup.py: Use GitHub for download_url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ Usage
 
 """,
         url='http://www.ruffus.org.uk',
-        download_url = "https://pypi.python.org/pypi/ruffus",
+        download_url = "https://github.com/cgat-developers/ruffus",
 
         install_requires = module_dependencies, #['multiprocessing>=1.0', 'json' ], #, 'python>=2.5'],
         setup_requires   = module_dependencies, #['multiprocessing>=1.0', 'json'],    #, 'python>=2.5'],


### PR DESCRIPTION
PyPI URL is derived from the PyPI name, so provides no benefit.
GitHub URL provides a reliable and fast alternative.