### PR TITLE
Run tests on Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.9"
 
 # Travis does not properly support this yet.
 # https://github.com/travis-ci/travis-ci/issues/9815

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   - "3.9"
-
-# Travis does not properly support this yet.
-# https://github.com/travis-ci/travis-ci/issues/9815
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 # all python versions tested via pip in tox
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,py36,py37
+envlist = py26,py27,py33,py34,py35,py36,py37,py39
 [testenv]
 deps=ez_setup
     argparse

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,py36,py37,py39
+envlist = py27,py35,py36,py37,py39
 [testenv]
 deps=ez_setup
     argparse


### PR DESCRIPTION
Hello,
I've been using Ruffus with Python 3.9 locally on the next Debian stable release. As far as I can tell, things work and all tests pass locally on 3.9, thus add it to tox/travis. What do you think ?  Thank you !