### PR TITLE
Fix doc build with Sphinx 4.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,9 +19,9 @@ import ruffus, ruffus.task, ruffus.ruffus_version
 
 
 def setup(app):
-   #app.add_javascript("custom.js")
+   # app.add_js_file("custom.js")
    if not on_rtd:
-       app.add_stylesheet("ruffus.css")
+       app.add_css_file("ruffus.css")
 
 
 # If extensions (or modules to document with autodoc) are in another directory,


### PR DESCRIPTION
`add_stylesheet` was deprecated in 1.8 and removed in 4.0 [1]. The replacement, `add_css_file` was added in 1.0.

[1] https://www.sphinx-doc.org/en/master/extdev/deprecated.html?highlight=add_stylesheet